### PR TITLE
Use uint for module parameter type for setup_timeout, remove -ve check

### DIFF
--- a/nf_conntrack_rtsp.c
+++ b/nf_conntrack_rtsp.c
@@ -68,7 +68,7 @@ module_param_array(ports, int, &num_ports, 0400);
 MODULE_PARM_DESC(ports, "port numbers of RTSP servers");
 module_param(max_outstanding, int, 0400);
 MODULE_PARM_DESC(max_outstanding, "max number of outstanding SETUP requests per RTSP session");
-module_param(setup_timeout, int, 0400);
+module_param(setup_timeout, uint, 0400);
 MODULE_PARM_DESC(setup_timeout, "timeout on for unestablished data channels");
 
 static char *rtsp_buffer;
@@ -517,10 +517,6 @@ init(void)
 
 	if (max_outstanding < 1) {
 		printk("nf_conntrack_rtsp: max_outstanding must be a positive integer\n");
-		return -EBUSY;
-	}
-	if (setup_timeout < 0) {
-		printk("nf_conntrack_rtsp: setup_timeout must be a positive integer\n");
 		return -EBUSY;
 	}
 


### PR DESCRIPTION
The module parameter setup_timeout is an unsigned int, so use uint
for a module parameter type. Since it is never going to be negative
also remove the redundant less than zero sanity check too. Issue
found with static analysis.

Addresses-Coverity: ("Unsigned compared against 0")
Signed-off-by: Colin Ian King <colin.king@canonical.com>