### PR TITLE
Fix build with Linux 5.3

### DIFF
--- a/netfilter_helpers.h
+++ b/netfilter_helpers.h
@@ -14,6 +14,8 @@
 /* Only include these functions for kernel code. */
 #ifdef __KERNEL__
 
+#include <net/netfilter/nf_conntrack_expect.h>
+
 #include <linux/ctype.h>
 #define iseol(c) ( (c) == '\r' || (c) == '\n' )
 
@@ -127,6 +129,15 @@ nf_nextline(char* p, uint len, uint* poff, uint* plineoff, uint* plinelen)
     return 1;
 }
 #endif /* NF_NEED_NEXTLINE */
+
+static inline int rtsp_nf_ct_expect_related(struct nf_conntrack_expect *expect)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+	return nf_ct_expect_related(expect, 0);
+#else
+	return nf_ct_expect_related(expect);
+#endif
+}
 
 #endif /* __KERNEL__ */
 

--- a/nf_conntrack_rtsp.c
+++ b/nf_conntrack_rtsp.c
@@ -41,7 +41,6 @@
 #include <net/tcp.h>
 
 #include <net/netfilter/nf_conntrack.h>
-#include <net/netfilter/nf_conntrack_expect.h>
 #include <net/netfilter/nf_conntrack_helper.h>
 #include "nf_conntrack_rtsp.h"
 
@@ -396,8 +395,8 @@ help_out(struct sk_buff *skb, unsigned char *rb_ptr, unsigned int datalen,
 					  &expinfo, rtp_exp, rtcp_exp);
 #endif
 		else {
-			if (nf_ct_expect_related(rtp_exp) == 0) {
-				if (rtcp_exp && nf_ct_expect_related(rtcp_exp) != 0) {
+			if (rtsp_nf_ct_expect_related(rtp_exp) == 0) {
+				if (rtcp_exp && rtsp_nf_ct_expect_related(rtcp_exp) != 0) {
 					nf_ct_unexpect_related(rtp_exp);
 					pr_info("nf_conntrack_expect_related failed for rtcp\n");
 					ret = NF_DROP;

--- a/nf_nat_rtsp.c
+++ b/nf_nat_rtsp.c
@@ -46,7 +46,6 @@
 #endif
 #include <net/netfilter/nf_nat_helper.h>
 #include "nf_conntrack_rtsp.h"
-#include <net/netfilter/nf_conntrack_expect.h>
 
 #include <linux/inet.h>
 #include <linux/ctype.h>
@@ -202,7 +201,7 @@ rtsp_mangle_tran(enum ip_conntrack_info ctinfo,
 	case pb_single:
 		for (loport = prtspexp->loport; loport != 0; loport++) { /* XXX: improper wrap? */
 			rtp_t->dst.u.udp.port = htons(loport);
-			if (nf_ct_expect_related(rtp_exp) == 0) {
+			if (rtsp_nf_ct_expect_related(rtp_exp) == 0) {
 				pr_debug("using port %hu\n", loport);
 				break;
 			}
@@ -215,12 +214,12 @@ rtsp_mangle_tran(enum ip_conntrack_info ctinfo,
 	case pb_range:
 		for (loport = prtspexp->loport; loport != 0; loport += 2) { /* XXX: improper wrap? */
 			rtp_t->dst.u.udp.port = htons(loport);
-			if (nf_ct_expect_related(rtp_exp) != 0) {
+			if (rtsp_nf_ct_expect_related(rtp_exp) != 0) {
 				continue;
 			}
 			hiport = loport + 1;
 			rtcp_exp->tuple.dst.u.udp.port = htons(hiport);
-			if (nf_ct_expect_related(rtcp_exp) != 0) {
+			if (rtsp_nf_ct_expect_related(rtcp_exp) != 0) {
 				nf_ct_unexpect_related(rtp_exp);
 				continue;
 			}
@@ -243,14 +242,14 @@ rtsp_mangle_tran(enum ip_conntrack_info ctinfo,
 	case pb_discon:
 		for (loport = prtspexp->loport; loport != 0; loport++) { /* XXX: improper wrap? */
 			rtp_t->dst.u.udp.port = htons(loport);
-			if (nf_ct_expect_related(rtp_exp) == 0) {
+			if (rtsp_nf_ct_expect_related(rtp_exp) == 0) {
 				pr_debug("using port %hu (1 of 2)\n", loport);
 				break;
 			}
 		}
 		for (hiport = prtspexp->hiport; hiport != 0; hiport++) { /* XXX: improper wrap? */
 			rtp_t->dst.u.udp.port = htons(hiport);
-			if (nf_ct_expect_related(rtp_exp) == 0) {
+			if (rtsp_nf_ct_expect_related(rtp_exp) == 0) {
 				pr_debug("using port %hu (2 of 2)\n", hiport);
 				break;
 			}


### PR DESCRIPTION
In Linux 5.3 nf_ct_expect_related() gained a flags argument.
Calls to this function are sprinkled throughout a couple of
source files, so rather than adding a #if to each call site, add
a wrapper which will use the appropriate prototype.

Signed-off-by: Seth Forshee <seth.forshee@canonical.com>