### PR TITLE
fix support for client_port=x/y Transport attribute

### DIFF
--- a/nf_conntrack_rtsp.c
+++ b/nf_conntrack_rtsp.c
@@ -351,7 +351,7 @@ help_out(struct sk_buff *skb, unsigned char *rb_ptr, unsigned int datalen,
 
 		rtp_exp->flags = 0;
 
-		if (expinfo.pbtype == pb_range) {
+		if (expinfo.pbtype == pb_range || expinfo.pbtype == pb_discon) {
 			pr_debug("setup expectation for rtcp\n");
 
 			be_hiport = htons(expinfo.hiport);

--- a/nf_nat_rtsp.c
+++ b/nf_nat_rtsp.c
@@ -248,8 +248,8 @@ rtsp_mangle_tran(enum ip_conntrack_info ctinfo,
 			}
 		}
 		for (hiport = prtspexp->hiport; hiport != 0; hiport++) { /* XXX: improper wrap? */
-			rtp_t->dst.u.udp.port = htons(hiport);
-			if (rtsp_nf_ct_expect_related(rtp_exp) == 0) {
+			rtcp_exp->tuple.dst.u.udp.port = htons(hiport);
+			if (rtsp_nf_ct_expect_related(rtcp_exp) == 0) {
 				pr_debug("using port %hu (2 of 2)\n", hiport);
 				break;
 			}
@@ -258,6 +258,11 @@ rtsp_mangle_tran(enum ip_conntrack_info ctinfo,
 			rbuf1len = sprintf(rbuf1, "%hu", loport);
 			rbufalen = sprintf(rbufa, hiport == loport+1 ?
 					   "%hu-%hu":"%hu/%hu", loport, hiport);
+		} else {
+			if (loport != 0)
+				nf_ct_unexpect_related(rtp_exp);
+			if (hiport != 0)
+				nf_ct_unexpect_related(rtcp_exp);
 		}
 		break;
 	}


### PR DESCRIPTION
Signed-off-by: Alin Nastac <alin.nastac@gmail.com>

In pb_discon case, RTCP expect was not created nor it was correctly handled by nf_nat_rtsp.c rtsp_mangle_tran().

Ported from https://github.com/openwrt/packages/pull/12338