### PR TITLE
Fix build with Linux 6.8

### DIFF
--- a/nf_conntrack_rtsp.c
+++ b/nf_conntrack_rtsp.c
@@ -550,7 +550,7 @@ init(void)
 		}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
-		strlcpy(hlpr->name, tmpname, sizeof(hlpr->name));
+		strscpy(hlpr->name, tmpname, sizeof(hlpr->name));
 #else
 		hlpr->name = tmpname;
 #endif


### PR DESCRIPTION
With commit
https://github.com/torvalds/linux/commit/57f22c8dab6b266ae36b89b073a4a33dea71e762 strlcpy has been removed in favor of strscpy. Thus giving us build error such as nf_conntrack_rtsp.c: error: implicit declaration of function strlcpy.

First reported on Gentoo Linux, please reffer:
https://bugs.gentoo.org/928590